### PR TITLE
fix: update fast-uri to 3.1.2 to fix CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1561,9 +1561,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
This PR updates the `fast-uri` dependency to version 3.1.2 to fix two high-severity vulnerabilities:

## Fixed Vulnerabilities

### CVE-2026-6321
**Path traversal via percent-encoded dot segments**
- Severity: HIGH
- Affected: fast-uri v3.1.0 and earlier
- An attacker could use percent-encoded path separators (%2F) and dot segments (%2E) to bypass path-based policy checks, allowing traversal to unintended directories.

### CVE-2026-6322
**Host confusion via percent-encoded authority delimiters**
- Severity: HIGH
- Affected: fast-uri v3.1.1 and earlier
- An attacker could use percent-encoded authority delimiters (%40 as @, %3A as :) to confuse URL parsing, turning `http://trusted.com%40evil.com/` into `http://trusted.com@evil.com/`, effectively changing the target host.

## Changes
- Updated `fast-uri` from 3.0.6 to 3.1.2 in `frontend/package-lock.json`

## Testing
- `npm install` completes successfully
- No breaking changes introduced

---
*This PR was created to address Dependabot security alerts.*